### PR TITLE
Simplify build_db workflow by removing unnecessary steps

### DIFF
--- a/.github/workflows/build_db.yml
+++ b/.github/workflows/build_db.yml
@@ -13,11 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install apt-get utilities
-      run: sudo apt-get install sharutils
-
-    - uses: actions/checkout@v2
-
     - name: Build Custom Database for MiSTer Downloader
       run: set -o pipefail && curl --fail --location https://raw.githubusercontent.com/theypsilon/Downloader_DB-Template_MiSTer/main/.github/build_db.py | python3 -
       env:


### PR DESCRIPTION
Removed installation of sharutils and checkout step.